### PR TITLE
missing a [super didReceiveMemoryWarning] call

### DIFF
--- a/ViewDeck/IIWrapController.m
+++ b/ViewDeck/IIWrapController.m
@@ -230,6 +230,7 @@
 
 - (void)didReceiveMemoryWarning {
     [self.wrappedController didReceiveMemoryWarning];
+//    [super didReceiveMemoryWarning];
 }
 
 - (id)forwardingTargetForSelector:(SEL)aSelector {


### PR DESCRIPTION
Fixes Xcode 6.3.1 Errors